### PR TITLE
Public schedule

### DIFF
--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -30,7 +30,7 @@ module ProductsHelper
   def public_calendar_link(product)
     return unless product.respond_to? :reservations
 
-    opts = if product.facility.show_instrument_availability?
+    opts = if product.facility.show_instrument_availability? || !session_user.nil?
       public_calendar_availability_options(product)
     else
       { class: ["fa fa-calendar fa-lg fa-fw"], title: t("instruments.public_schedule.icon") }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1048,7 +1048,7 @@ en:
     public_schedule:
       title: Schedule
       place_reservation: Place Reservation
-      icon: Public Schedule
+      icon: Login required
       available: Available
       unavailable: Unavailable
     schedule:


### PR DESCRIPTION
# Release Notes

Override the "Show Instrument Availability Status" indicator.
- when checked, users can see the availability status of the instrument without login.
- when unchecked, requires login to see the availability status of instruments.