### PR TITLE
Fixed -  product allows user input note

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,7 +12,7 @@ class ApplicationController < ActionController::Base
 
   # Make the following methods available to all views
   helper_method :cross_facility?
-  helper_method :current_facility, :session_user, :manageable_facilities, :operable_facilities, :acting_user, :acting_as?, :check_acting_as, :current_cart, :backend?
+  helper_method :current_facility, :session_user, :manageable_facilities, :operable_facilities, :acting_user, :acting_as?, :check_acting_as, :current_cart, :backend?, :has_delegated?
   helper_method :open_or_facility_path
 
   before_action :set_paper_trail_whodunnit ,:check_agreement
@@ -197,6 +197,10 @@ class ApplicationController < ActionController::Base
 
   def acting_user
     @acting_user ||= User.find_by(id: session[:acting_user_id]) || session_user
+  end
+
+  def has_delegated?
+    return has_delegated
   end
 
   def acting_as?

--- a/app/controllers/instruments_controller.rb
+++ b/app/controllers/instruments_controller.rb
@@ -39,12 +39,14 @@ class InstrumentsController < ProductsCommonController
   def show
     instrument_for_cart = InstrumentForCart.new(@product)
     # TODO: Remove this instance variable-not used anywhere but tests
-    @add_to_cart = false
-    if(has_delegated && session[:is_selected_user] == true) 
-      @add_to_cart = true
-    else 
-      @add_to_cart = instrument_for_cart.purchasable_by?(acting_user, session_user)
-    end
+    @add_to_cart = instrument_for_cart.purchasable_by?(acting_user, session_user)
+    
+    # @add_to_cart = false
+    # if(has_delegated && session[:is_selected_user] == true) 
+    #   @add_to_cart = true
+    # else 
+    #   @add_to_cart = instrument_for_cart.purchasable_by?(acting_user, session_user)
+    # end
     
     if @add_to_cart
       redirect_to new_facility_instrument_single_reservation_path(current_facility, @product)

--- a/app/controllers/instruments_controller.rb
+++ b/app/controllers/instruments_controller.rb
@@ -39,14 +39,14 @@ class InstrumentsController < ProductsCommonController
   def show
     instrument_for_cart = InstrumentForCart.new(@product)
     # TODO: Remove this instance variable-not used anywhere but tests
-    @add_to_cart = instrument_for_cart.purchasable_by?(acting_user, session_user)
+    # @add_to_cart = instrument_for_cart.purchasable_by?(acting_user, session_user)
     
-    # @add_to_cart = false
-    # if(has_delegated && session[:is_selected_user] == true) 
-    #   @add_to_cart = true
-    # else 
-    #   @add_to_cart = instrument_for_cart.purchasable_by?(acting_user, session_user)
-    # end
+    @add_to_cart = false
+    if(has_delegated && session[:is_selected_user] == true) 
+      @add_to_cart = true
+    else 
+      @add_to_cart = instrument_for_cart.purchasable_by?(acting_user, session_user)
+    end
     
     if @add_to_cart
       redirect_to new_facility_instrument_single_reservation_path(current_facility, @product)

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -44,7 +44,7 @@ class OrdersController < ApplicationController
     facility_ability = Ability.new(session_user, @order.facility, self)
     @order.being_purchased_by_admin = facility_ability.can?(:act_as, @order.facility)
     @order.validate_order! if @order.new?
-    @is_delegated = has_delegated
+    # @is_delegated = has_delegated
 
   end
 

--- a/app/helpers/orders_helper.rb
+++ b/app/helpers/orders_helper.rb
@@ -25,7 +25,12 @@ module OrdersHelper
   end
 
   def show_note_input_to_user?(order_detail)
-    acting_as? || order_detail.product.user_notes_field_mode.visible?
+    if has_delegated?
+      order_detail.product.user_notes_field_mode.visible?
+    else   
+      acting_as? || order_detail.product.user_notes_field_mode.visible?
+    end
+    # aacting_as? || order_detail.product.user_notes_field_mode.visible?
   end
 
 end

--- a/app/views/orders/_cart_row.html.haml
+++ b/app/views/orders/_cart_row.html.haml
@@ -18,7 +18,7 @@
           name: "note#{order_detail.id}" }
 
       - if acting_as?
-        - if @is_delegated
+        - if has_delegated?
           = hidden_field_tag :reference_id, nil
         - else
           = odf.input :reference_id ,

--- a/app/views/orders/_edit_date.html.haml
+++ b/app/views/orders/_edit_date.html.haml
@@ -1,4 +1,5 @@
-- unless @is_delegated
+-# - unless @is_delegated
+- unless has_delegated?
   - classes = ['collapsable']
 - else 
   - classes = ['collapsable', 'hidden']

--- a/app/views/reservations/_account_field.html.haml
+++ b/app/views/reservations/_account_field.html.haml
@@ -18,7 +18,7 @@
         - if acting_as?
           = render_view_hook "after_account", f: f, order_detail: @order_detail
 
-      - if show_note_input_to_user?(@order_detail) && (@is_delegated == false || @is_delegated.nil?)
+      - if show_note_input_to_user?(@order_detail)
         .span6
           = f.input :note, 
             label: @order_detail.product.user_notes_label.presence,

--- a/app/views/reservations/_account_field.html.haml
+++ b/app/views/reservations/_account_field.html.haml
@@ -18,9 +18,12 @@
         - if acting_as?
           = render_view_hook "after_account", f: f, order_detail: @order_detail
 
-      - if show_note_input_to_user?(@order_detail) && @is_delegated == false
+      - if show_note_input_to_user?(@order_detail) && (@is_delegated == false || @is_delegated.nil?)
         .span6
-          = f.input :note,
+          = f.input :note, 
             label: @order_detail.product.user_notes_label.presence,
             required: @order_detail.product.user_notes_field_mode.required?,
             hint: t(".note_hint")
+
+:javascript
+  $("#reservation_note").css("width", "85%");

--- a/app/views/reservations/new.html.haml
+++ b/app/views/reservations/new.html.haml
@@ -30,7 +30,7 @@
   = render "reservations/account_field", f: f unless @order_detail.bundled?
   = render "reservations/reservation_fields", f: f
 
-  - if acting_as? && @is_delegated == false
+  - if acting_as? && (@is_delegated == false || @is_delegated.nil?)
     .row
       .span4
         = f.input :reference_id

--- a/app/views/reservations/new.html.haml
+++ b/app/views/reservations/new.html.haml
@@ -29,8 +29,8 @@
   = f.error_messages
   = render "reservations/account_field", f: f unless @order_detail.bundled?
   = render "reservations/reservation_fields", f: f
-
-  - if acting_as? && (@is_delegated == false || @is_delegated.nil?)
+  
+  - if acting_as? && has_delegated? == false
     .row
       .span4
         = f.input :reference_id


### PR DESCRIPTION
# Release Notes
Bug fix:
If the product allows user to input note when booking, the order screen should have a note field for user to input



