### PR TITLE
Add auto top up function to payment source

### DIFF
--- a/app/services/nufs_account_builder.rb
+++ b/app/services/nufs_account_builder.rb
@@ -8,7 +8,7 @@ class NufsAccountBuilder < AccountBuilder
 
   # Override strong_params for `build` account.
   def account_params_for_build
-    super + [{ account_number_parts: NufsAccount.account_number_field_names}] + [:allows_allocation] + [:affiliate_id] + [:affiliate_other] + [:alert_threshold] 
+    super + [{ account_number_parts: NufsAccount.account_number_field_names}] + [:allows_allocation] + [:affiliate_id] + [:affiliate_other] + [:alert_threshold] + [:is_auto_top_up] 
   end
 
   # Hooks into superclass's `build` method.
@@ -27,6 +27,7 @@ class NufsAccountBuilder < AccountBuilder
   [
     :description,
     :allows_allocation,
+    :is_auto_top_up,
     :affiliate_id,
     :affiliate_other, 
     :alert_threshold

--- a/app/views/accounts/show.html.haml
+++ b/app/views/accounts/show.html.haml
@@ -14,8 +14,16 @@
   = f.input :committed_amt, label: text("account_allocations.new.committed_amt"), as: :readonly
   = f.input :total_expense, label: text("account_allocations.new.total_expense"), as: :readonly
   = f.input :free_balance, label: text("account_allocations.new.free_balance"), as: :readonly
+
   - if @account.type == "NufsAccount"
     = f.input :alert_threshold, label: text("account_allocations.new.alert_threshold")
+
+  - if @account.type == "NufsAccount"
+    = f.label  :is_auto_top_up, label: text("account_allocations.new.is_auto_top_up")
+    = f.check_box :is_auto_top_up
+
+  <br>
+  <br>
 
   = f.input :type, as: :hidden, input_html: { value: @account.type, name: "type" }
   - if @account.affiliate

--- a/app/views/facility_accounts/account_fields/_nufs_account.html.haml
+++ b/app/views/facility_accounts/account_fields/_nufs_account.html.haml
@@ -5,6 +5,11 @@
 
 = render partial: 'facility_accounts/account_fields/affiliate', locals: { f: f }
 
+= f.label :facility_accounts, t("account_allocations.new.is_auto_top_up")
+= f.check_box :is_auto_top_up
+
+<br>
+<br>
 = f.label :facility_accounts, t("facility_accounts.account_fields.label.allows_allocation")
 = f.check_box :allows_allocation
 

--- a/app/views/facility_accounts/show.html.haml
+++ b/app/views/facility_accounts/show.html.haml
@@ -25,6 +25,9 @@
 
   - if @account.type == "NufsAccount"
     = f.input  :alert_threshold, label: text("account_allocations.new.alert_threshold"), as: :readonly
+ 
+  - if @account.type == "NufsAccount"
+    = f.input  :is_auto_top_up, label: text("account_allocations.new.is_auto_top_up"), as: :readonly
     
   -# TODO: use render_view_hook instead
   - if lookup_context.exists? "facility_accounts/#{@account.class.name.underscore}/show", [], true

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1345,6 +1345,7 @@ en:
       total_expense: "Total Expense Amount"
       free_balance: "Free balance"
       alert_threshold: "Alert threshold"
+      is_auto_top_up: "Auto Top up"
       expires_at: "Valid Until"
     member_allocation_table:
       th:

--- a/db/migrate/20210202064907_addis_auto_top_up_to_accounts.rb
+++ b/db/migrate/20210202064907_addis_auto_top_up_to_accounts.rb
@@ -1,0 +1,7 @@
+class AddisAutoTopUpToAccounts < ActiveRecord::Migration[5.2]
+  def change
+    change_table :accounts do |t|
+      t.boolean "is_auto_top_up", default: false, null: false
+    end
+  end
+end


### PR DESCRIPTION
# Release Notes

Add auto top-up checkbox to payment source detail.  Auto creates funding top-up request if payment source does not have sufficient fund to settle the bills.