### PR TITLE
change error message

### DIFF
--- a/app/controllers/single_reservations_controller.rb
+++ b/app/controllers/single_reservations_controller.rb
@@ -39,7 +39,7 @@ class SingleReservationsController < ApplicationController
         render "reservations/new"
       end
     else 
-      flash.now[:error] = I18n.t("controllers.reservations.create.expires_at")
+      flash.now[:error] = I18n.t("controllers.reservations.create.null_payment_source")
       set_windows
       render "reservations/new"
     end

--- a/config/locales/en.controllers.yml
+++ b/config/locales/en.controllers.yml
@@ -126,6 +126,7 @@ en:
         success: "The reservation was successfully created."
         admin_hold_warning: "Warning: You have scheduled over an administrative hold."
         expires_at: "Payment source expired "
+        null_payment_source: "Please select a payment source"
       order_detail_removed: |
         The instrument order has been removed from your cart.
         Please add it again to make a reservation.


### PR DESCRIPTION
# Release Notes

Update no payment source selected error message.

original = Payment source expired.
new = Please select a payment source
