### PR TITLE
update cheque account detail

### DIFF
--- a/vendor/engines/c2po/app/models/cheque_or_other_account.rb
+++ b/vendor/engines/c2po/app/models/cheque_or_other_account.rb
@@ -3,7 +3,7 @@
 class ChequeOrOtherAccount < Account
 
 #  include AffiliateAccount
-#  include ReconcilableAccount
+  include ReconcilableAccount
 
 #  attr_readonly :account_number
 #  before_validation :setup_false_credit_card_number

--- a/vendor/engines/c2po/app/services/cheque_or_other_account_builder.rb
+++ b/vendor/engines/c2po/app/services/cheque_or_other_account_builder.rb
@@ -14,7 +14,8 @@ class ChequeOrOtherAccountBuilder < AccountBuilder
       :account_number,
       :description,
       :formatted_expires_at,
-      :name_on_card
+      :name_on_card,
+      :remittance_information,
     ]
   end
 
@@ -22,7 +23,8 @@ class ChequeOrOtherAccountBuilder < AccountBuilder
   def account_params_for_update
     [
       :description,
-      :formatted_expires_at
+      :formatted_expires_at,
+      :remittance_information
     ]
   end
   # Hooks into superclass's `build` method.

--- a/vendor/engines/c2po/app/views/c2po/facility_accounts/show/_remittance_information.html.haml
+++ b/vendor/engines/c2po/app/views/c2po/facility_accounts/show/_remittance_information.html.haml
@@ -1,2 +1,2 @@
-- if @account.is_a?(CreditCardAccount) || @account.is_a?(PurchaseOrderAccount)
+- if @account.is_a?(CreditCardAccount) || @account.is_a?(PurchaseOrderAccount) || @account.is_a?(ChequeOrOtherAccount)
   = f.input :remittance_information, value_method: Proc.new { |value| value.present? ? simple_format(value) : "None Entered" }

--- a/vendor/engines/c2po/app/views/facility_accounts/account_fields/_cheque_or_other_account.html.haml
+++ b/vendor/engines/c2po/app/views/facility_accounts/account_fields/_cheque_or_other_account.html.haml
@@ -1,8 +1,9 @@
 = f.input :account_number, label: t('facility_accounts.account_fields.label.co_number'), required: true
 = f.input :name_on_card, label: t('facility_accounts.account_fields.label.co_name'), required: true
 
-=f.input :formatted_expires_at, required: true, 
-  input_html: { class: "datepicker" }, 
+=f.input :formatted_expires_at, required: true,
+  input_html: { class: "datepicker" },
   label: "Valid Until"
 
 = f.input :description, required: true, hint: t('facility_accounts.account_fields.label.all_instruct'), hint_html: { class: 'help-inline' }
+= render partial: 'facility_accounts/account_fields/remittance_information', locals: { f: f }


### PR DESCRIPTION
# Release Notes

- add 'bill to' option for cheque account
- include cheque account to ReconcilableAccount, allow admin to reconcile cheque statements
