### PR TITLE
handle reservation save issues

### DIFF
--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -5,6 +5,7 @@ require "date"
 class Reservation < ApplicationRecord
 
   acts_as_paranoid # soft deletes
+  has_paper_trail
 
   include DateHelper
   include Reservations::DateSupport
@@ -320,7 +321,7 @@ class Reservation < ApplicationRecord
   end
 
   def has_actuals?
-    actual_start_at.present? && actual_end_at.present?
+    actual_start_at.present? && actual_end_at.present? && actual_end_at > actual_start_at
   end
 
   def started?

--- a/app/services/order_details/param_updater.rb
+++ b/app/services/order_details/param_updater.rb
@@ -70,7 +70,9 @@ class OrderDetails::ParamUpdater
 
     @order_detail.transaction do
       assign_price_changed_by_user
-      @order_detail.reservation.save_as_user(@editing_user) if @order_detail.reservation
+      if @order_detail.reservation.present?
+        @order_detail.reservation.save_as_user(@editing_user) || log_and_rollback
+      end
       if order_status_id && order_status_id.to_i != @order_detail.order_status_id
         change_order_status(order_status_id, @options[:cancel_fee]) || raise(ActiveRecord::Rollback)
       else
@@ -89,6 +91,13 @@ class OrderDetails::ParamUpdater
   end
 
   private
+
+  def log_and_rollback
+     # TODO: Determine why reservations are failing to save at this point, then remove logging.
+     Rollbar.error("Failed save for reservation #{@order_detail.reservation.id}: #{@order_detail.reservation.errors.full_messages}") if defined?(Rollbar)
+     # If the reservation save fails, the order detail should stay in the problem queue.
+     raise(ActiveRecord::Rollback)
+   end
 
   def assign_price_changed_by_user
     if @order_detail.actual_costs_match_calculated?

--- a/db/migrate/20210126230013_add_object_changes_to_versions.rb
+++ b/db/migrate/20210126230013_add_object_changes_to_versions.rb
@@ -1,0 +1,7 @@
+class AddObjectChangesToVersions < ActiveRecord::Migration[5.2]
+  def change
+    change_table :versions do |t|
+      t.text :object_changes
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -963,6 +963,7 @@ ActiveRecord::Schema.define(version: 2021_02_19_035843) do
     t.string "whodunnit"
     t.text "object", limit: 4294967295
     t.datetime "created_at"
+    t.text "object_changes"
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
@@ -1080,7 +1081,7 @@ ActiveRecord::Schema.define(version: 2021_02_19_035843) do
   add_foreign_key "user_roles", "users"
 
   create_view "account_user_expenses", sql_definition: <<-SQL
-      select `au`.`id` AS `account_user_id`,`od`.`account_id` AS `account_id`,`o`.`user_id` AS `user_id`,sum((case when isnull(`od`.`actual_cost`) then `od`.`estimated_cost` else `od`.`actual_cost` end)) AS `expense_amt` from ((`order_details` `od` join `orders` `o` on((`o`.`id` = `od`.`order_id`))) join `account_users` `au` on(((`au`.`account_id` = `od`.`account_id`) and (`au`.`user_id` = `o`.`user_id`)))) where isnull(`od`.`canceled_at`) group by `au`.`id`,`od`.`account_id`,`o`.`user_id`
+      select `au`.`id` AS `account_user_id`,`od`.`account_id` AS `account_id`,`o`.`user_id` AS `user_id`,sum((case when isnull(`od`.`actual_cost`) then `od`.`estimated_cost` else `od`.`actual_cost` end)) AS `expense_amt` from ((`order_details` `od` join `orders` `o` on(((`o`.`id` = `od`.`order_id`) and (`o`.`state` <> 'validated')))) join `account_users` `au` on(((`au`.`account_id` = `od`.`account_id`) and (`au`.`user_id` = `o`.`user_id`)))) where isnull(`od`.`canceled_at`) group by `au`.`id`,`od`.`account_id`,`o`.`user_id`
   SQL
   create_view "account_free_balances", sql_definition: <<-SQL
       select `aue`.`account_id` AS `account_id`,`a2`.`committed_amt` AS `committed_amt`,sum(`aue`.`expense_amt`) AS `total_expense` from (`account_user_expenses` `aue` join `accounts` `a2` on((`a2`.`id` = `aue`.`account_id`))) group by `aue`.`account_id`

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -1434,9 +1434,15 @@ RSpec.describe Reservation do
       expect(reservation).not_to be_has_actuals
     end
 
+    it "should not have actuals if the start and end are the same" do
+      reservation.actual_start_at = Time.zone.now
+      reservation.actual_end_at = reservation.actual_start_at
+      expect(reservation).not_to be_has_actuals
+    end
+
     it "should have actuals" do
       reservation.actual_start_at = Time.zone.now
-      reservation.actual_end_at = Time.zone.now
+      reservation.actual_end_at = Time.zone.now + 1.minute
       expect(reservation).to be_has_actuals
     end
   end


### PR DESCRIPTION
# Release Notes

(Bug fix migrate from tablexi)

Add paper trail to reservation model, add object_changes column to versions
Log and rollback when reservation save fails