### PR TITLE
Create user when the user does not exists when assign payment source member

### DIFF
--- a/app/controllers/account_users_controller.rb
+++ b/app/controllers/account_users_controller.rb
@@ -8,7 +8,7 @@ class AccountUsersController < ApplicationController
   before_action :init_account
 
   load_and_authorize_resource
-
+  
   def initialize
     @active_tab = "accounts"
     super
@@ -16,6 +16,69 @@ class AccountUsersController < ApplicationController
 
   # GET /accounts/:account_id/account_users/user_search
   def user_search
+  end
+
+  def create_user
+    # account_id = params[:account_id];
+    # @facility = Facility.joins("INNER JOIN account_facility_joins on account_facility_joins.facility_id = facilities.id INNER JOIN accounts ON account_facility_joins.account_id = accounts.id WHERE accounts.id = #{account_id}")
+  end
+
+  # POST /facilities/:facility_id/users
+  def insert_user
+    @user = username_lookup(params[:username])
+    # authorize! :create, @user
+    if @user.nil?
+      flash[:error] = text("netid_not_found")
+      redirect_to account_account_users_path
+    elsif @user.persisted?
+      flash[:error] = text("user_already_exists", username: @user.username)
+      redirect_to account_account_users_path
+    elsif @user.save
+      LogEvent.log(@user, :create, current_user)
+      @user.create_default_price_group!
+      save_user_success(@user)
+
+      # Add Payment Source
+      @account_user = AccountUser.grant(@user, 'Purchaser', @account, by: session_user)
+      if @account_user.persisted?
+        LogEvent.log(@account_user, :create, current_user)
+        flash[:notice] = text("create.success", user: @user.full_name, account_type: @account.type_string)
+        redirect_to account_account_users_path(@account)
+      else
+        flash.now[:error] = text("create.error", user: @user.full_name, account_type: @account.type_string)
+        render :new
+      end
+    else
+      flash[:error] = text("create.error", message: @user.errors.full_messages.to_sentence)
+      redirect_to account_account_users_path
+    end
+  end
+
+  def save_user_success(user)
+    flash[:notice] = text("create.success")
+    if session_user.manager_of?(current_facility)
+      add_role = html("create.add_role", link: facility_facility_user_map_user_path(current_facility, user), inline: true)
+      flash[:notice].safe_concat(add_role)
+    end
+    # Notifier.new_user(user: user, password: user.password).deliver_later
+  end
+  
+  def add_user
+    @user = username_lookup(params[:username_lookup])
+    render layout: false
+  end
+
+  def service_username_lookup(username)
+    LdapAuthentication::UserLookup.new.call(username)
+  end
+
+  def username_lookup(username)
+    return nil if username.blank?
+    username_database_lookup(username.strip) || service_username_lookup(username.strip)
+  end
+
+  def username_database_lookup(username)
+    User.find_by("LOWER(username) = ?", username.downcase)
   end
 
   # GET /accounts/:account_id/account_users/new

--- a/app/views/account_users/add_user.html.haml
+++ b/app/views/account_users/add_user.html.haml
@@ -1,0 +1,24 @@
+- if @user.nil? && params[:has_netid] == "yes"
+  %p.alert.alert-info= t(".netid_not_found")
+- elsif @user.nil?
+  %p.alert.alert-info= t(".email_not_found")
+  -# %p= t(".main_html", link: new_external_facility_users_path(current_facility, email: params[:username_lookup]))
+- elsif @user.persisted?
+  %p.alert.alert-info= text(".user_already_exists", username: @user.username)
+- else
+  %p.notice= t(".found")
+  %table.table.table-striped.table-hover
+    %thead
+      %tr
+        %th
+        %th Username
+        %th Last Name
+        %th First Name
+        %th Email
+    %tbody
+      %tr
+        %td= link_to "Add User", insert_user_account_account_users_path(username: @user.username), method: :post
+        %td= @user.username
+        %td= @user.last_name
+        %td= @user.first_name
+        %td= @user.email

--- a/app/views/account_users/create_user.html.haml
+++ b/app/views/account_users/create_user.html.haml
@@ -1,0 +1,76 @@
+= content_for :breadcrumb do
+  %ul.breadcrumb
+    %li= order_reservation_breadcrumb
+    %li &raquo;
+    %li= t(".submenu", account_number: @account.account_number)
+
+= content_for :tabnav do
+  = render :partial => 'shared/tabnav_account', :locals => {:secondary_tab => 'members'}
+= content_for :h1 do
+  = t('.head')
+
+:javascript
+  function changeUsernameLookupText(from, to){
+    $('#username_lookup p,#username_lookup label').each(function() {
+      $(this).text($(this).text().replace(new RegExp(from, 'ig'), to));
+    });
+
+    $('#username_lookup input[type=submit]').each(function() {
+      $(this).val($(this).val().replace(new RegExp(from, 'ig'), to));
+    });
+  }
+
+  $(document).ready(function() {
+
+    function has_netid_change() {
+      if ($('#has_netid').val() == 'yes')
+        changeUsernameLookupText('#{t(".js.email")}', '#{t(".js.id")}');
+      else
+        changeUsernameLookupText('#{t(".js.id")}', '#{t(".js.email")}');
+    }
+
+    $('#has_netid').change(function(e) {
+      has_netid_change();
+      $('#search_results').html('');
+    });
+
+
+    $('#username_search_form').submit(function(e) {
+      e.preventDefault(); //Prevent the normal submission action
+      var form       = $(this);
+      var submit     = $("input[type='submit']",form);
+      var submit_val = submit.val();
+      var error_div  = $('div#error_result');
+      submit.val("Please Wait...");
+      submit.attr("disabled", true);
+      error_div.html('');
+      jQuery.ajax({
+        type: "post",
+        data: form.serialize(),
+        url:  form.attr('action'),
+        timeout: 25000,
+        success: function(r) {
+          $('#search_results').html(r);
+          submit.val(submit_val);
+          submit.attr("disabled", false);
+        },
+        error: function() {
+          error_div.html('<p class="error">#{t('.js.error')}</p>');
+          submit.val(submit_val);
+          submit.attr("disabled", false);
+        }
+      });
+    });
+  });
+
+%h2= t('.subhead')
+-# = simple_form_for :search, :url => add_user_account_account_users_path do |f|
+= simple_form_for :search, :url => add_user_account_account_users_path, :html => { :id => 'username_search_form', :class => 'form-inline' }, :defaults => { :required => false } do |f|
+  #error_result
+  %p= t('.intro')
+  #username_lookup
+    = f.input :username_lookup, :label => t('.label.id'), :hint => t('.instruct'), :input_html => { :name => 'username_lookup' }
+    = submit_tag t('.lookup'), :class => 'btn'
+
+    
+#search_results

--- a/app/views/account_users/user_search.html.haml
+++ b/app/views/account_users/user_search.html.haml
@@ -19,6 +19,8 @@
   = submit_tag "Search", class: "btn"
   = hidden_field_tag :account_id, @account.id
   = hidden_field_tag :search_type, "account_account_user"
-  = hidden_field_tag :create_link, "false"
+  -# = hidden_field_tag :create_link, "false"
+  = hidden_field_tag :create_link, "true" 
+  = hidden_field_tag :is_payment_source, "true"
 %br
 #result

--- a/app/views/search/_create_new_user.html.haml
+++ b/app/views/search/_create_new_user.html.haml
@@ -4,7 +4,7 @@
     - if SettingsHelper.feature_on?(:lookup_netids)
       -# = link_to t(".link"), new_facility_user_path(@facility)
       - if params[:is_payment_source] == "true" 
-        = link_to t(".link"), create_user_account_account_users_path(params[:account_id])
+        = link_to t(".link_for_assign"), create_user_account_account_users_path(params[:account_id])
       -else 
         = link_to t(".link"), new_facility_user_path(@facility)
     - else

--- a/app/views/search/_create_new_user.html.haml
+++ b/app/views/search/_create_new_user.html.haml
@@ -2,6 +2,10 @@
   %p
     = t(".prompt")
     - if SettingsHelper.feature_on?(:lookup_netids)
-      = link_to t(".link"), new_facility_user_path(@facility)
+      -# = link_to t(".link"), new_facility_user_path(@facility)
+      - if params[:is_payment_source] == "true" 
+        = link_to t(".link"), create_user_account_account_users_path(params[:account_id])
+      -else 
+        = link_to t(".link"), new_facility_user_path(@facility)
     - else
       = link_to t(".link"), new_external_facility_users_path(@facility)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -930,6 +930,7 @@ en:
     create_new_user:
       prompt: Can't find the user you're looking for?
       link: Create a new user
+      link_for_assign: Assign to a new user
     user_search_results:
       blank_term: Please enter a search term
       more_users_alert:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -969,7 +969,28 @@ en:
       instruct: "Search for a user to add to the %{account_type}, (%{account})"
       label:
         search: "Search by name, NetID, or username"
-
+    add_user:
+      email_not_found: "No user information was found in the university databases."
+      main_html: "You may add a new external user by clicking <a href=\"%{link}\">Add a new external user</a>."
+      netid_not_found: "The user could not be located in the university database.  Please make sure you typed the NetID correctly."
+      email_not_found: "No user information was found in the university databases."
+      found: "The following user was found.  Click \"Add User\" to allow this user access to system."
+      user_already_exists: "The user %{username} already exists in system"
+      
+    create_user:
+      submenu: "%{account_number}"
+      head: "Add Payment Source Member"
+      subhead: "Look up"
+      lookup: "Look up NetID"
+      instruct: "Enter the user's NetID"
+      intro: "Some information about this user may already exist in university databases.  Please choose whether the user you wish to add has a NetID and enter the requested information.  If the user exists already, you will be able to add her with a single click."
+      js:
+        id: "NetID"
+        email: "Email Address"
+        error: "An error was encountered while looking up the NetID"
+      label:
+        id: "NetID"
+      
   accounts:
     role:
         owner: Owner

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,6 +67,10 @@ Rails.application.routes.draw do
     resources :account_users, only: [:new, :destroy, :create, :index] do
       collection do
         get "user_search"
+        get "create_user"
+        get "new_external"
+        post "add_user"
+        post "insert_user"
       end
     end
 


### PR DESCRIPTION
# Release Notes

User account is automatically created when the user first log in the system via NetID. When assigning payment source member, many members may not already have user accounts. Therefore, we added a create account through netID functions when assigning payment source members. Will added an additional function for payment source owner to assign payment source to those who does not have user account. System will generate user account via NetID and assign he/she as payment source member.