### PR TITLE
Insufficient fund update

### DIFF
--- a/app/controllers/facility_insufficient_fund_controller.rb
+++ b/app/controllers/facility_insufficient_fund_controller.rb
@@ -3,7 +3,7 @@
 class FacilityInsufficientFundController < ApplicationController
 
   include SortableColumnController
-  
+
   admin_tab     :all
   before_action :authenticate_user!
   before_action :check_acting_as
@@ -24,23 +24,23 @@ class FacilityInsufficientFundController < ApplicationController
     raise ActionController::RoutingError.new("Notifications disabled with a zero-day review period") unless SettingsHelper.has_review_period?
   end
 
-  # GET /facilities/notifications
+  # GET /facilities/insufficient_fund
   def index
-    order_details = OrderDetail.need_notification.for_facility(current_facility)
+    order_details = OrderDetail.with_insufficient_fund.for_facility(current_facility)
     @search_form = TransactionSearch::SearchForm.new(params[:search])
     @search = TransactionSearch::Searcher.billing_search(order_details, @search_form, include_facilities: current_facility.cross_facility?)
     @date_range_field = @search_form.date_params[:field]
 
     if params[:sort].nil?
       @order_details = @search.order_details
-    else 
+    else
       @order_details = @search.order_details.reorder(sort_clause)
     end
-    
 
-    @order_details = @order_details.select{ |x| !x.has_sufficient_fund? }
-    
-    @order_detail_action = :send_notifications
+
+#    @order_details = @order_details.select{ |x| !x.has_sufficient_fund? }
+
+#    @order_detail_action = :send_notifications
   end
 
   # POST /facilities/notifications/send
@@ -116,13 +116,13 @@ class FacilityInsufficientFundController < ApplicationController
   end
 
   def sort_lookup_hash
-    {      
+    {
       "order_number" => "order_details.order_id",
       "fulfilled_date" => "order_details.fulfilled_at",
       "product_name" => "products.name",
       "ordered_for" => ["#{User.table_name}.last_name", "#{User.table_name}.first_name"],
       "payment_source" => "accounts.description",
-      "actual_subsidy" => "order_details.actual_cost", 
+      "actual_subsidy" => "order_details.actual_cost",
       # "actual_subsidy" => "order_details.actual_subsidy",
       "state" => "order_details.state",
     }

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -25,6 +25,7 @@ class Account < ApplicationRecord
   has_many :funding_requests
   has_one :owner, -> { where(user_role: AccountUser::ACCOUNT_OWNER, deleted_at: nil) }, class_name: "AccountUser"
   has_one :owner_user, through: :owner, source: :user
+  has_one :account_free_balance
   has_many :business_admins, -> { where(user_role: AccountUser::ACCOUNT_ADMINISTRATOR, deleted_at: nil) }, class_name: "AccountUser"
 
   has_many :notify_user_roles, -> { where(user_role: AccountUser.admin_user_roles, deleted_at: nil) }, class_name: "AccountUser"
@@ -281,7 +282,8 @@ class Account < ApplicationRecord
 
 
   def total_expense
-    AccountUserExpense.where(account_id: id).sum("expense_amt")
+    account_free_balance.total_expense
+    #AccountFreeBalance.where(account_id: id).first.total_expense
   end
 
   def free_balance

--- a/app/models/account_free_balance.rb
+++ b/app/models/account_free_balance.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AccountFreeBalance < ApplicationRecord
+
+  belongs_to :account, required: true
+
+  def to_log_s
+    "#{account_id} / #{total_expense}"
+  end
+end

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -176,6 +176,19 @@ class OrderDetail < ApplicationRecord
       .where(problem: false)
   }
 
+  scope :with_insufficient_fund, lambda {
+    joins(:product)
+      .where(state: "complete")
+      .with_price_policy
+      .account_insuffifient_fund
+      .not_disputed
+      .where(problem: false)
+  }
+
+  scope :account_insuffifient_fund, lambda {
+    joins("INNER JOIN account_free_balances ON account_free_balances.account_id = order_details.account_id and account_free_balances.total_expense > account_free_balances.committed_amt")
+  }
+
   def self.all_movable
     ordered_at
       .unreconciled
@@ -521,10 +534,10 @@ class OrderDetail < ApplicationRecord
   end
 
   def get_fo_journal_status?
-    return "" if fo_journal_id.blank?    
+    return "" if fo_journal_id.blank?
     @status = FoJournal.where(id: fo_journal_id)
-    
-    return "" if @status.blank?    
+
+    return "" if @status.blank?
 
     return @status[0].status
   end


### PR DESCRIPTION
# Release Notes

When failed to create FO journal due to insufficient fund. The record will remain in 'Billing'>'Orders with Insufficient Fund'.