### PR TITLE
Fix payment source order UI

### DIFF
--- a/app/views/facility_account_orders/index.html.haml
+++ b/app/views/facility_account_orders/index.html.haml
@@ -41,12 +41,14 @@
 
           %td= od.order_status
           %td.currency
-            - if od.cost_estimated?
-              %span.estimated_cost= od.wrapped_total
-            - elsif od.price_policy.blank?
-              = t(".unassigned")
-            - else
-              %span.actual_cost= od.wrapped_total
+            = od.wrapped_total
+
+            -# - if od.cost_estimated?
+            -#   %span.estimated_cost= od.wrapped_total
+            -# - elsif od.price_policy.blank?
+            -#   = t(".unassigned")
+            -# - else
+            -#   %span.actual_cost= od.wrapped_total
       %tr
         %td.centered{colspan: 5}= will_paginate(@order_details)
 


### PR DESCRIPTION
# Release Notes

Fix UI: payment source order list, the estimated amount should have one * instead of two.
