### PR TITLE
Redirect to My Reservation page when cancel already started reservation.

### DIFF
--- a/app/controllers/order_details_controller.rb
+++ b/app/controllers/order_details_controller.rb
@@ -47,7 +47,9 @@ class OrderDetailsController < ApplicationController
       end
       redirect_to(reservations_path)
     else
-      raise ActiveRecord::RecordNotFound
+      # raise ActiveRecord::RecordNotFound
+      flash[:error] = I18n.t("order_details.edit.conflict")
+      redirect_to(reservations_path)
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -835,6 +835,7 @@ en:
   order_details:
     edit:
       failure: This order is not currently editable.
+      conflict : Reservation already started, cancel failed
     show:
       head:
         # h1: "Order #%{order_number}"


### PR DESCRIPTION
# Release Notes

Issue: Show record not found page when reservation already started and the user clicks the 'Cancel' button.
Fix: redirect user to "My Reservation" with validation message instead of record not found page.