### PR TITLE
Support supervisor

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,7 +15,7 @@ class ApplicationController < ActionController::Base
   helper_method :current_facility, :session_user, :manageable_facilities, :operable_facilities, :acting_user, :acting_as?, :check_acting_as, :current_cart, :backend?, :has_delegated?
   helper_method :open_or_facility_path
 
-  before_action :set_paper_trail_whodunnit ,:check_agreement
+  before_action :set_paper_trail_whodunnit,:check_supervisor, :check_agreement
   before_action :check_delegations
   
   # Navigation tabs configuration
@@ -45,15 +45,18 @@ class ApplicationController < ActionController::Base
 
   def check_delegations
     # Avoid fake delegations
-    if(!session[:is_selected_user] == true && !session[:acting_user_id].nil? && !session[:acting_user_id].eql?(""))
-      redirect_to "/" if !has_delegated
-    end
+    
+    unless session[:had_supervisor] == 0
+      if(!session[:is_selected_user] == true && !session[:acting_user_id].nil? && !session[:acting_user_id].eql?(""))
+        redirect_to "/" if !has_delegated
+      end
 
-    # Detect is first login action and redirect to account selection
-    # if(!request.env['PATH_INFO'].eql?('/agreement') && !request.env['PATH_INFO'].include?('/user_delegations/') && !request.env['PATH_INFO'].eql?('/users/sign_in') && !request.env['PATH_INFO'].eql?('/users/sign_out') && session[:is_selected_user].nil?)
-    if (!session_user.nil? && !request.env['PATH_INFO'].eql?('/agree_terms') && !request.env['PATH_INFO'].eql?('/agreement') && !request.env['PATH_INFO'].include?('/user_delegations/') && !request.env['PATH_INFO'].eql?('/users/sign_in') && !request.env['PATH_INFO'].eql?('/users/sign_out') )
-      unless session[:is_selected_user] == true
-        redirect_to '/user_delegations/switch'
+      # Detect is first login action and redirect to account selection
+      # if(!request.env['PATH_INFO'].eql?('/agreement') && !request.env['PATH_INFO'].include?('/user_delegations/') && !request.env['PATH_INFO'].eql?('/users/sign_in') && !request.env['PATH_INFO'].eql?('/users/sign_out') && session[:is_selected_user].nil?)
+      if (!session_user.nil? && !request.env['PATH_INFO'].eql?('/agree_terms') && !request.env['PATH_INFO'].eql?('/agreement') && !request.env['PATH_INFO'].include?('/user_delegations/') && !request.env['PATH_INFO'].eql?('/users/sign_in') && !request.env['PATH_INFO'].eql?('/users/sign_out') )
+        unless session[:is_selected_user] == true
+          redirect_to '/user_delegations/switch'
+        end
       end
     end
   end
@@ -61,41 +64,60 @@ class ApplicationController < ActionController::Base
   def after_sign_in_path_for(resource)
     '/orders/pending'
   end
-    
-  def check_agreement
-    #only user login can visit agreement
-    if  request.env['PATH_INFO'].eql?('/agreement') && session_user.blank? 
-      redirect_to '/facilities'
-    end
 
-    # when user login and page is not agreement or agreement api
-      if !session_user.blank? && !request.env['PATH_INFO'].eql?('/agreement') && !request.env['PATH_INFO'].eql?('/agree_terms') && !request.env['PATH_INFO'].eql?('/users/sign_out')
-        
-        # get rocord from db when frist time store data in session 
-        if session[:user_agreement_record] == nil
-          #puts "[check_agreement][get record][user_agreement_record]"
-          session[:user_agreement_record] = UserAgreement.where(user_id:session_user).count
-        end
-
-        # get rocord from db when frist time store data in session 
-        if session[:user_agreement_record] > 0 
-          if session[:accept] == nil
-            #puts "[check_agreement][get record][accept]"
-            session[:accept] = UserAgreement.where(user_id:session_user).first.accept
-          end 
-        end
-
-        #puts "[check_agreement]session[:accept]" + (session[:accept] ? "true" : "false")
-        #puts "[check_agreement]session[:user_agreement_record]" +session[:user_agreement_record].to_s
-
-        if session[:accept] == 0
-          redirect_to '/agreement'
-        else
-          if !session[:accept]
-            redirect_to '/agreement' 
-          end
+  def check_supervisor
+    if !session_user.blank? && !request.env['PATH_INFO'].eql?('/users/sign_out') && !request.env['PATH_INFO'].eql?('/users/sign_in') && !session_user.administrator?
+      session[:had_supervisor] = session_user.supervisor.blank? ? 0 : 1
+      if session[:had_supervisor] == 0
+        #Check role
+        if (session_user.is_academic == true)
+          @user = User.find(session_user[:id]) 
+          @user.update_attributes(supervisor: @user.username)
+          session[:had_supervisor] = 1
+          redirect_to '/facilities'
+        else 
+          redirect_to '/no_supervisor' unless request.env['PATH_INFO'].eql?('/no_supervisor')
         end
       end
+    end
+  end
+    
+  def check_agreement  
+    unless session[:had_supervisor] == 0
+      #only user login can visit agreement
+      if  request.env['PATH_INFO'].eql?('/agreement') && session_user.blank? 
+        redirect_to '/facilities'
+      end
+
+      # when user login and page is not agreement or agreement api
+        if !session_user.blank? && !request.env['PATH_INFO'].eql?('/agreement') && !request.env['PATH_INFO'].eql?('/agree_terms') && !request.env['PATH_INFO'].eql?('/users/sign_out')
+          
+          # get rocord from db when frist time store data in session 
+          if session[:user_agreement_record] == nil
+            #puts "[check_agreement][get record][user_agreement_record]"
+            session[:user_agreement_record] = UserAgreement.where(user_id:session_user).count
+          end
+
+          # get rocord from db when frist time store data in session 
+          if session[:user_agreement_record] > 0 
+            if session[:accept] == nil
+              #puts "[check_agreement][get record][accept]"
+              session[:accept] = UserAgreement.where(user_id:session_user).first.accept
+            end 
+          end
+
+          #puts "[check_agreement]session[:accept]" + (session[:accept] ? "true" : "false")
+          #puts "[check_agreement]session[:user_agreement_record]" +session[:user_agreement_record].to_s
+
+          if session[:accept] == 0
+            redirect_to '/agreement'
+          else
+            if !session[:accept]
+              redirect_to '/agreement' 
+            end
+          end
+        end
+    end
   end
      
     # after login redirect user to agreement page

--- a/app/controllers/no_supervisors_controller.rb
+++ b/app/controllers/no_supervisors_controller.rb
@@ -1,0 +1,13 @@
+
+class NoSupervisorsController < ApplicationController
+
+    include AZHelper
+
+    def index
+      if session[:had_supervisor] == 1 || session[:had_supervisor].blank? || session_user.administrator?
+        redirect_to '/facilities'
+      end
+    end
+    
+  end
+  

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -150,7 +150,7 @@ class UsersController < ApplicationController
   end
 
   def edit_user_params
-    @user_form.admin_editable? ? params.require(:user).except(:internal).permit(:email, :first_name, :last_name, :username) : empty_params
+    @user_form.admin_editable? ? params.require(:user).except(:internal).permit(:email, :first_name, :last_name, :username, :phone, :supervisor) : empty_params
   end
 
   def price_group_params

--- a/app/views/no_supervisors/index.html.haml
+++ b/app/views/no_supervisors/index.html.haml
@@ -1,0 +1,1 @@
+<h1> No Supervisor</h1>

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -21,6 +21,11 @@
     = f.input :username, readonly: !@user_form.username_editable?
     - if current_user.administrator? && SettingsHelper.feature_on?(:user_based_price_groups)
       = f.input :internal?, label: text(".internal"), as: :select, default: false
+    
+    = f.label :phone
+    = f.number_field  :phone, readonly: !@user_form.admin_editable?
+    = f.input :supervisor, readonly: !@user_form.admin_editable?
+
     = f.button :submit, text("shared.update"), class: ["btn", "btn-primary"]
     &nbsp;
     = link_to text("shared.cancel"), facility_users_path

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -19,6 +19,9 @@
   = f.input :suspension_note if f.object.suspended? && current_user.administrator?
   = f.input :expired_at if f.object.expired?
   = f.input :expired_note if f.object.expired? && current_user.administrator?
+  
+  = f.input :phone
+  = f.input :supervisor
 
   = render_view_hook "additional_user_fields", f: f
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,9 @@ Rails.application.routes.draw do
   # root route
   root to: "public#index"
 
+  
+  get "/no_supervisor", to: "no_supervisors#index"
+
   post "agree_terms" , to: "user_agreements#agree"
   post "get_is_agree_terms" , to: "user_agreements#get_is_agree_terms"
 

--- a/db/migrate/20210323093425_add_supervisor_to_user.rb
+++ b/db/migrate/20210323093425_add_supervisor_to_user.rb
@@ -2,7 +2,7 @@ class AddSupervisorToUser < ActiveRecord::Migration[5.2]
   def change
     change_table :users do |t|
       t.string "supervisor" ,limit: 100
-      t.boolean "is_academic", default: false
+      # t.boolean "is_academic", default: false
     end
   end
 end

--- a/db/migrate/20210323093425_add_supervisor_to_user.rb
+++ b/db/migrate/20210323093425_add_supervisor_to_user.rb
@@ -1,0 +1,8 @@
+class AddSupervisorToUser < ActiveRecord::Migration[5.2]
+  def change
+    change_table :users do |t|
+      t.string "supervisor" ,limit: 100
+      t.boolean "is_academic", default: false
+    end
+  end
+end


### PR DESCRIPTION
# Release Notes
Add supervisor for user table.
Allow admin to edit supervisor and phone.
Add no-supervisor checking before the first-time login.

If login user = academic staff, the supervisor will prefill to be him/herself.
For all other users, they need to contact the facility admin to verify their supervisor.

