### PR TITLE
Show project title if payment source is affiliate with pgms

### DIFF
--- a/app/controllers/account_allocations_controller.rb
+++ b/app/controllers/account_allocations_controller.rb
@@ -31,37 +31,38 @@ class AccountAllocationsController < ApplicationController
 
     @account_users ||= AccountUser.where(account_id: @account.id, deleted_at: nil).where.not(user_role: "Owner")
 
-    if @account.can_allocate?
-      render :new
-    else
-      redirect_to account_path(@account)
-    end
-
-
+    # if @account.can_allocate?
+    #   render :new
+    # else
+    #   redirect_to account_path(@account)
+    # end
+    
+    render :new
   end
 
   def update_allocation
     puts "update allocation"
-
-    au = params[:account_user]
-    auv = au.values
-    @id = params[:account_id]
-
+    
     #load account info before update attribute
     @account = session_user.accounts.find(params[:account_id])
 
-    #load form field to model
-    @account.assign_attributes(account_users_attributes: auv)
-    if @account.save
-      flash.now[:notice] = "Save success" #text("update.success")
-    else
-      flash.now[:error] = text("errors")
-
+    if (!@account.allows_allocation.nil? && @account.allows_allocation == true)
+      au = params[:account_user]
+      auv = au.values
+      @id = params[:account_id]
+  
+  
+      #load form field to model
+      @account.assign_attributes(account_users_attributes: auv)
+      if @account.save
+        flash.now[:notice] = "Save success" #text("update.success")
+      else
+        flash.now[:error] = text("errors")
+      end
     end
-
+    
     #load model for form display
     @account_users = @account.account_users
-
 
     render :new
   end

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -49,6 +49,21 @@ class AccountsController < ApplicationController
     #@account = Account.find(params[:id] || params[:account_id])
   end
 
+  def is_allocation
+    is_allocation = params.permit(:is_show)["is_show"]
+    account_id = params.permit(:id)["id"]
+
+    @account = Account.find(account_id);
+
+    unless(account_id.nil?)
+      unless(@account.nil?)
+        @account.update_attributes(allows_allocation: is_allocation)
+      end
+    end
+
+    render json: true
+  end
+
   # PUT /accounts/:account_id/
   def update
     id = params[:id]

--- a/app/views/account_allocations/new.html.haml
+++ b/app/views/account_allocations/new.html.haml
@@ -21,5 +21,43 @@
     = f.input :committed_amt, label: text("account_allocations.new.committed_amt")
     = f.input :total_expense, label: text("account_allocations.new.total_expense")
     = f.input :free_balance, label: text("account_allocations.new.free_balance")
+    = f.label :facility_accounts, t("account_allocations.new.allows_allocation")
+    = f.check_box :allows_allocation
 
 = render "member_allocation_table"
+
+
+:javascript
+
+  $("#account_allows_allocation").attr("checked") ? $("#new_account_user").show() : $("#new_account_user").hide();
+
+  $(document).on('change', '#account_allows_allocation', function() {
+    
+    var b = $(this).is(':checked');
+
+    var msg = "";
+
+    $("#account_allows_allocation").attr("checked") ? msg = "Are you sure you want to disable allocations?" :msg ="Are you sure you want to enable allocations?" ;
+
+    var confirmBox = confirm(msg);
+    
+    
+    
+
+    if (confirmBox == true) {
+      let data0 = {is_show: b};
+      let path = "/accounts/"+ #{@account.id} + "/account_allocations";
+      let ajx_path = "/accounts/"+ #{@account.id} + "/is_allocation";
+    
+      $.ajax({
+        url: ajx_path,
+        method: "POST",
+        data: data0,
+        success: function(data) {          
+          $(location).attr('href', path)
+        },dataType: 'json'
+      });
+    } else {
+        $("#account_allows_allocation").prop('checked', !b);
+    };
+  });

--- a/app/views/accounts/show.html.haml
+++ b/app/views/accounts/show.html.haml
@@ -21,11 +21,11 @@
   = f.input :total_expense, label: text("account_allocations.new.total_expense"), as: :readonly
   = f.input :free_balance, label: text("account_allocations.new.free_balance"), as: :readonly
 
-  - if @account.type == "NufsAccount"
-    = f.label :facility_accounts, t("account_allocations.new.allows_allocation")
-    = f.check_box :allows_allocation
-  <br>
-  <br>
+  -# - if @account.type == "NufsAccount"
+  -#   = f.label :facility_accounts, t("account_allocations.new.allows_allocation")
+  -#   = f.check_box :allows_allocation
+  -# <br>
+  -# <br>
 
   - if @account.type == "NufsAccount"
     = f.input :alert_threshold, label:  text("account_allocations.new.alert_threshold_input")

--- a/app/views/accounts/show.html.haml
+++ b/app/views/accounts/show.html.haml
@@ -41,7 +41,8 @@
     = f.input :affiliate_id, as: :hidden
     = f.input :affiliate_other, as: :hidden
     = f.input :affiliate, input_html: { value: @account.affiliate_to_s }, as: :readonly
-
+    - if @account.affiliate.name.include?('PGMS')
+      = f.input :project_title, input_html: { value: @account.project_title}, as: :readonly
   <br>
   <br>
 

--- a/app/views/facility_accounts/show.html.haml
+++ b/app/views/facility_accounts/show.html.haml
@@ -41,6 +41,8 @@
 
   - if @account.affiliate
     = f.input :affiliate, input_html: { value: @account.affiliate_to_s }
+    - if @account.affiliate.name.include?('PGMS')
+      = f.input :project_title, input_html: { value: @account.project_title}, as: :readonly
 
   = f.input :display_status, input_html: { class: @account.suspended? ? "suspended-account" : "" }
 

--- a/app/views/shared/_tabnav_account.html.haml
+++ b/app/views/shared/_tabnav_account.html.haml
@@ -5,5 +5,6 @@
   = tab t('shared.tabnav_account.members'), account_account_users_path(@account), (secondary_tab == 'members')
   - if @account.type == 'NufsAccount'
     = tab t('shared.tabnav_account.funding_requests'), account_funding_requests_path(@account), (secondary_tab == 'funding_requests')
-  - if @account.can_allocate?
+  -# - if @account.can_allocate?
+  - if @account.type == 'NufsAccount'
     = tab t(".allocations"), account_account_allocations_path(@account), (secondary_tab == "allocations")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,7 @@ Rails.application.routes.draw do
     resources :statements, only: [:show, :index]
     member do
       get "user_search"
+      post "is_allocation", to: "accounts#is_allocation"
     end
 
     if SettingsHelper.feature_on? :suspend_accounts


### PR DESCRIPTION
Add project title to payment source detail page 
    -	 If the payment source is affiliated with PGMS, the project title will display
Move "Allows allocation" to the "Allocations" tab
    -	If the checkbox is ticked, enable the quota for input
    -	If the checkbox unchecked, disable quota input