### PR TITLE
Remove column sorting when reassign chart strings

### DIFF
--- a/app/controllers/concerns/new_inprocess_controller.rb
+++ b/app/controllers/concerns/new_inprocess_controller.rb
@@ -18,7 +18,6 @@ module NewInprocessController
       @order_details = @search.order_details.includes(:order_status).joins_assigned_users.reorder(sort_clause)
     end                                     
     
-
     respond_to do |format|
       format.html { @order_details = @order_details.paginate(page: params[:page]) }
       format.csv { handle_csv_search }
@@ -33,7 +32,7 @@ module NewInprocessController
 
   def sort_lookup_hash
     {
-      "order_number" => ["order_details.id"],
+      "order_number" => ["order_details.order_id"],
       "assigned_to" => ["assigned_users.last_name", "assigned_users.first_name", "order_statuses.name", "order_details.ordered_at"],
       "ordered_at" => "order_details.ordered_at",
       "ordered_for" => ["#{User.table_name}.last_name", "#{User.table_name}.first_name"],

--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -289,7 +289,7 @@ class FacilitiesController < ApplicationController
 
   def sort_lookup_hash
     {      
-      "order_number" => ["order_details.id"],
+      "order_number" => ["order_details.order_id"],
       "fulfilled_date" => "order_details.fulfilled_at",
       "product_name" => "products.name",
       "ordered_for" => ["#{User.table_name}.last_name", "#{User.table_name}.first_name"],

--- a/app/views/facilities/reassign_chart_strings.html.haml
+++ b/app/views/facilities/reassign_chart_strings.html.haml
@@ -17,4 +17,4 @@
 
 .row
   .span9
-    = render "shared/transactions/table_inside", order_details: @order_details
+    = render "shared/transactions/table_inside", order_details: @order_details, is_sort: "0"

--- a/app/views/shared/transactions/_table_inside.html.haml
+++ b/app/views/shared/transactions/_table_inside.html.haml
@@ -1,30 +1,56 @@
-= will_paginate(order_details) if order_details.respond_to? :total_pages
-- is_insufficient_fund|=false
+= will_paginate(order_details) if order_details.respond_to? :total_page
+
+- is_sort||="1"
+- is_insufficient_fund||=false
 
 %table.table.table-striped.table-hover.dense.old-table
   %thead
-    %tr
-      - if(!is_insufficient_fund)
-        -if @order_detail_action or @order_detail_link
-          %th
-      -# %th= sortable "order_number", Order.model_name.human
-      -# %th= OrderDetail.model_name.human
-      %th= sortable "order_number", t("shared.order_id")
-      %th= t("shared.order_detail_id")
-      %th.nowrap= sortable "fulfilled_date", OrderDetail.human_attribute_name(@date_range_field)
-      - if @extra_date_column
-        %th.nowrap= OrderDetail.human_attribute_name(@extra_date_column_header || @extra_date_column)
-      - if current_facility.blank? || cross_facility?
-        %th= sortable "product_name", Facility.model_name.human
-      %th.order-note= OrderDetail.human_attribute_name("description")
-      %th.nowrap= sortable "ordered_for", OrderDetail.human_attribute_name("user")
-      - unless @account
-        %th= sortable "payment_source", Account.model_name.human
-        %th= Account.human_attribute_name("owner")
-      %th.currency= OrderDetail.human_attribute_name("cost")+"(HKD)"
-      %th= sortable "status",OrderDetail.human_attribute_name("order_status")
-      - if local_assigns[:show_statements]
-        %th= Statement.model_name.human
+    - if (is_sort == "1")
+      %tr
+        - if(!is_insufficient_fund)
+          -if @order_detail_action or @order_detail_link
+            %th
+        -# %th= sortable "order_number", Order.model_name.human
+        -# %th= OrderDetail.model_name.human
+        %th= sortable "order_number", t("shared.order_id")
+        %th= t("shared.order_detail_id")
+        %th.nowrap= sortable "fulfilled_date", OrderDetail.human_attribute_name(@date_range_field)
+        - if @extra_date_column
+          %th.nowrap= OrderDetail.human_attribute_name(@extra_date_column_header || @extra_date_column)
+        - if current_facility.blank? || cross_facility?
+          %th= sortable "product_name", Facility.model_name.human
+        %th.order-note= OrderDetail.human_attribute_name("description")
+        %th.nowrap= sortable "ordered_for", OrderDetail.human_attribute_name("user")
+        - unless @account
+          %th= sortable "payment_source", Account.model_name.human
+          %th= Account.human_attribute_name("owner")
+        %th.currency= OrderDetail.human_attribute_name("cost")+"(HKD)"
+        %th= sortable "status",OrderDetail.human_attribute_name("order_status")
+        - if local_assigns[:show_statements]
+          %th= Statement.model_name.human
+    -else 
+      %tr
+        - if(!is_insufficient_fund)
+          -if @order_detail_action or @order_detail_link
+            %th
+        -# %th= sortable "order_number", Order.model_name.human
+        -# %th= OrderDetail.model_name.human
+        %th= t("shared.order_id")
+        %th= t("shared.order_detail_id")
+        %th.nowrap= OrderDetail.human_attribute_name(@date_range_field)
+        - if @extra_date_column
+          %th.nowrap= OrderDetail.human_attribute_name(@extra_date_column_header || @extra_date_column)
+        - if current_facility.blank? || cross_facility?
+          %th= Facility.model_name.human
+        %th.order-note= OrderDetail.human_attribute_name("description")
+        %th.nowrap= OrderDetail.human_attribute_name("user")
+        - unless @account
+          %th= Account.model_name.human
+          %th= Account.human_attribute_name("owner")
+        %th.currency= OrderDetail.human_attribute_name("cost")+"(HKD)"
+        %th= OrderDetail.human_attribute_name("order_status")
+        - if local_assigns[:show_statements]
+          %th= Statement.model_name.human
   %tbody
     / We need to keep track of how many columns there are to the left of the Cost column,
     / so we can position the Total correctly.


### PR DESCRIPTION
# Release Notes

Remove column sorting in Billing>Move Transactions>Reassign Chart Strings.