### PR TITLE
Use price_group.name for internal base price

### DIFF
--- a/app/models/price_group.rb
+++ b/app/models/price_group.rb
@@ -49,7 +49,8 @@ class PriceGroup < ApplicationRecord
   end
 
   def name
-    master_internal? ? "#{I18n.t('institution_name')} #{self[:name]}" : self[:name]
+    #master_internal? ? "#{I18n.t('institution_name')} #{self[:name]}" :
+    self[:name]
   end
 
   def to_s


### PR DESCRIPTION
# Release Notes

Use database's price group name instead of from settings.