### PR TITLE
Disable new user welcome email

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -245,7 +245,7 @@ class UsersController < ApplicationController
       add_role = html("create.add_role", link: facility_facility_user_map_user_path(current_facility, user), inline: true)
       flash[:notice].safe_concat(add_role)
     end
-    Notifier.new_user(user: user, password: user.password).deliver_later
+    # Notifier.new_user(user: user, password: user.password).deliver_later
     redirect_to facility_users_path(user: user.id)
   end
 


### PR DESCRIPTION
# Release Notes
Background: System will send a welcome email when the administrator creates a new user.

Disable the welcome email.
