### PR TITLE
assign internal price to student user

### DIFF
--- a/vendor/engines/saml_authentication/lib/saml_authentication/user_updater.rb
+++ b/vendor/engines/saml_authentication/lib/saml_authentication/user_updater.rb
@@ -40,7 +40,7 @@ module SamlAuthentication
       user.update!(attributes)
 
       if user.sign_in_count == 0
-        if user.user_type == 'Staff'
+        if user.user_type == 'Staff' || user.user_type == 'Student'
           user.update_to_internal_price_group!
         end
       end


### PR DESCRIPTION
# Release Notes

Set student's price group to internal when system auto create student user.