### PR TITLE
Rename delegate to assistant

### DIFF
--- a/app/controllers/user_delegations_controller.rb
+++ b/app/controllers/user_delegations_controller.rb
@@ -53,9 +53,9 @@ class UserDelegationsController < ApplicationController
   def index
     @user_delegation = UserDelegation.new
     @user_id = session[:acting_user_id] || session_user[:id]
-#    @user_id = session_user[:id]    
+#    @user_id = session_user[:id]
     @current_type = "my_delegation"
-    
+
     # @assigned_list = UserDelegation.find_by ("delegator = #{session_user[:id]} AND deleted_at IS NULL " )
     @assigned_list ||= UserDelegation.where(delegator: session[:acting_user_id] || session_user[:id], deleted_at: nil)
 
@@ -73,9 +73,9 @@ class UserDelegationsController < ApplicationController
     @user_id = session_user[:id]
     @count ||= User.check_academic_user_and_payment_source(@user_id).count
     @current_type = "my_delegation"
-    
+
     @delegate_info = user_delegation_params
-    
+
     # delegatee = service_username_lookup(@delegate_info["delegatee"].strip)
     delegatee= User.find_by(username: @delegate_info["delegatee"].strip)
     # delegator = User.find(session_user[:id])
@@ -85,14 +85,14 @@ class UserDelegationsController < ApplicationController
 
     if (delegatee.nil? || delegator.nil?)
       # flash[:error] = text("#{@delegate_info["delegatee"].strip} cannot be found") if delegatee.nil?
-      flash[:error] = text("User cannot found") if delegatee.nil?
+      flash[:error] = text(" User not found ") if delegatee.nil?
     elsif (delegatee.username.eql?(delegator.username))
-      flash[:error] = text("delegator cannot be delegatee")
-    else 
+      flash[:error] = text(" Cannot assign yourself ")
+    else
       @user_delegation_list ||= UserDelegation.where(delegatee: delegatee.username, delegator: delegator.id, deleted_at: nil).count
 
       if (@user_delegation_list > 0)
-        flash[:error] = text("#{delegatee.username} has been delegated")
+        flash[:error] = text("#{delegatee.username} has been assigned")
       elsif (!delegatee.user_type.eql?("Staff"))
         flash[:error] = "Invalid user"
       else
@@ -100,11 +100,11 @@ class UserDelegationsController < ApplicationController
         if @user_delegation.save
           LogEvent.log(@user_delegation, :create, delegator)
           UserDelegationMailer.notify(delegatee.first_name + " " + delegatee.last_name, delegator.email,  delegator.first_name+ " " + delegator.last_name).deliver_later
-          flash[:notice] = text("#{@user_delegation.delegatee} delegated")
+          flash[:notice] = text("#{@user_delegation.delegatee} assigned")
           has_error = false
           redirect_to action: :index
         else
-          flash[:error] = text("#{delegatee.username} could not be delegated")
+          flash[:error] = text("#{delegatee.username} could not be assigned")
         end
       end
     end
@@ -135,9 +135,9 @@ class UserDelegationsController < ApplicationController
         user_delegation.deleted_by =  session[:acting_user_id] || session_user[:id]
         if user_delegation.save
           LogEvent.log(user_delegation, :delete, delegator)
-          flash[:notice] = "Delegate #{user_delegation.delegatee} was removed."
+          flash[:notice] = "Assistant #{user_delegation.delegatee} was removed."
         else
-          flash[:error] = "Delegatee #{user_delegation.delegatee} could not be removed"
+          flash[:error] = "Assistant #{user_delegation.delegatee} could not be removed"
         end
       end
     end

--- a/app/views/user_delegations/index.html.haml
+++ b/app/views/user_delegations/index.html.haml
@@ -3,7 +3,7 @@
   = t("views.user_delegation.header")
 = error_messages_for :user
 
-<h3>Please note that when you assign a delegatee, he/she can : </h3>
+<h3>Please note that when you assign an assistant, he/she can : </h3>
 <h5>(1) Sign the facilities Terms and Conditions on behalf of you</h5>
 <h5>(2) Make item purchase / instrument reservation on behalf of you</h5>
 <h5>(3) Manage your payment source, e.g. assign payment source member, make funding request</h5>
@@ -12,7 +12,7 @@
   %ul.nav.nav-tabs
     = tab "My Profile", edit_current_profile_path, (@current_type == "my_profile")
     - if @count > 0
-      = tab "My Delegation", user_delegations_path, (@current_type == "my_delegation")
+      = tab "My Assistant", user_delegations_path, (@current_type == "my_delegation")
 
 
 -# <h1> #{t("views.user_delegation.header")} </h1>
@@ -23,7 +23,7 @@
 -#     = f.input :delegatee
 -#     = f.input :delegator, as: :hidden, input_html: { value: @user_id}
 -#     = f.button :submit, class: ["btn", "btn-primary"]
--# - else 
+-# - else
 -#   %table.table.table-striped.table-hover
 -#     %thead
 -#       %th= t("views.user_delegation.table.name")
@@ -33,9 +33,9 @@
 
 = simple_form_for(@user_delegation) do |f|
   = f.error_notification
-  = f.input :delegatee
+  = f.input :delegatee, label: t("views.user_delegation.delegatee")
   = f.input :delegator, as: :hidden, input_html: { value: @user_id}
-  = f.button :submit, class: ["btn", "btn-primary"]
+  = f.button :submit, "Assign", class: ["btn", "btn-primary"]
 
 <br>
 <br>
@@ -47,8 +47,8 @@
         %th= t("views.user_delegation.table.name")
         %th= t("views.user_delegation.table.date")
     %tbody
-      - @assigned_list.each do |od| 
+      - @assigned_list.each do |od|
         %tr
           %td= od.delegatee
-          %td= format_usa_date(od.created_at)          
+          %td= format_usa_date(od.created_at)
           %td= link_to t("views.user_delegation.table.button_name"), od, data: { confirm: t("views.user_delegation.message") }, method: :delete

--- a/config/locales/views/en.user_delegations.yml
+++ b/config/locales/views/en.user_delegations.yml
@@ -1,7 +1,9 @@
 en:
   views:
     user_delegation:
-      header: My Delegation 
+      header: My Assistant
+      delegatee: NetID of My Assistant
+      submit: Assign
       table:
         name: "NetID"
         date: "Assign date"

--- a/config/locales/views/en.user_delegations_mailer.yml
+++ b/config/locales/views/en.user_delegations_mailer.yml
@@ -1,11 +1,11 @@
 en:
   views:
     user_delegation:
-        subject:  "URFMS delegate assinged "
+        subject:  "URFMS assistant assinged "
         body: |
-          Dear %{delegator_name}, 
+          Dear %{delegator_name},
 
-          Please note that you have assigned %{delegatee_name} as your delegate. He/She can :
+          Please note that you have assigned %{delegatee_name} as your assistant. He/She can :
 
           (1) Sign the facilities Terms and Conditions on behalf of you
 


### PR DESCRIPTION
# Release Notes

Rename delegate to assistant. Example: "My Delegation" to "My Assistant"