### PR TITLE
Bug fix save allocation without member

### DIFF
--- a/app/views/account_allocations/_member_allocation_table.html.haml
+++ b/app/views/account_allocations/_member_allocation_table.html.haml
@@ -1,25 +1,27 @@
 - can_edit_accounts = SettingsHelper.feature_on? :edit_accounts
 
-= simple_form_for AccountUser.new, url: { action: :update_allocation}, method: "POST" do |f|
-  = f.error_messages
-  = f.error_notification
-  %table.table.table-striped.table-hover
-    %thead
-      %tr
-        %th= t(".th.name")
-        %th= t(".th.role")
-        %th= t(".th.allocation_amt") + " (HKD)"
-        %th= t(".th.expense_amt") + " (HKD)"
-        %th= t(".th.quota_balance") + " (HKD)"
-    %tbody
-      - @account_users.each do |od|
-        = f.simple_fields_for od.id.to_s, od do |p|
-          - if od.user != @account.owner_user
-            %tr
-              %td= Users::NamePresenter.new(od.user, username_label: true).full_name
-              %td= AccountUserPresenter.new(od).localized_role
-              %td= p.input :allocation_amt, label: false
-              %td= number_to_currency(od.expense.to_s(:delimited))
-              %td= number_to_currency(od.quota_balance.to_s(:delimited))
-              = p.hidden_field :id ,  value: AccountUserPresenter.new(od).id.to_s
-  = f.button :submit, t(".save"), class: "btn btn-primary"
+
+- if !@account_users.empty?
+  = simple_form_for AccountUser.new, url: { action: :update_allocation}, method: "POST" do |f|
+    = f.error_messages
+    = f.error_notification
+    %table.table.table-striped.table-hover
+      %thead
+        %tr
+          %th= t(".th.name")
+          %th= t(".th.role")
+          %th= t(".th.allocation_amt") + " (HKD)"
+          %th= t(".th.expense_amt") + " (HKD)"
+          %th= t(".th.quota_balance") + " (HKD)"
+      %tbody
+        - @account_users.each do |od|
+          = f.simple_fields_for od.id.to_s, od do |p|
+            - if od.user != @account.owner_user
+              %tr
+                %td= Users::NamePresenter.new(od.user, username_label: true).full_name
+                %td= AccountUserPresenter.new(od).localized_role
+                %td= p.input :allocation_amt, label: false
+                %td= number_to_currency(od.expense.to_s(:delimited))
+                %td= number_to_currency(od.quota_balance.to_s(:delimited))
+                = p.hidden_field :id ,  value: AccountUserPresenter.new(od).id.to_s
+    = f.button :submit, t(".save"), class: "btn btn-primary"


### PR DESCRIPTION
# Release Notes
If no payment source member, allocation page will not show member table
