### PR TITLE
handle empty first name issue when login via SAML

### DIFF
--- a/vendor/engines/saml_authentication/lib/saml_authentication/user_updater.rb
+++ b/vendor/engines/saml_authentication/lib/saml_authentication/user_updater.rb
@@ -42,6 +42,10 @@ module SamlAuthentication
         attributes["first_name"] = " "
       end
 
+      if attributes["first_name"].nil?
+        attributes["first_name"] = " "
+      end
+
       user.update!(attributes)
 
       if user.sign_in_count == 0

--- a/vendor/engines/saml_authentication/lib/saml_authentication/user_updater.rb
+++ b/vendor/engines/saml_authentication/lib/saml_authentication/user_updater.rb
@@ -37,6 +37,11 @@ module SamlAuthentication
         end
       end
 
+      #in case user do not have first name, set it to empty space to pass validation
+      unless attributes.key?("first_name")
+        attributes["first_name"] = " "
+      end
+
       user.update!(attributes)
 
       if user.sign_in_count == 0


### PR DESCRIPTION
# Release Notes

When auto create user from SAML login, first name may be empty. Set first name to empty space in case it's empty.
